### PR TITLE
Add tests of updated numpy x.x behavior and set CONDA_NPY for recipe tests

### DIFF
--- a/tests/test-recipes/build_recipes.sh
+++ b/tests/test-recipes/build_recipes.sh
@@ -5,6 +5,12 @@ set -x
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+# Set CONDA_NPY for all tests. Since CONDA_NPY should only affect recipes
+# that use a build requirement of 'numpy x.x' this should not affect
+# any existing tests that do not use that build requirement.
+
+export CONDA_NPY=1.9
+
 # Recipes that should fail and give some error
 
 for recipe in metadata/*/; do

--- a/tests/test-recipes/metadata/numpy_build_run_xx/meta.yaml
+++ b/tests/test-recipes/metadata/numpy_build_run_xx/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: conda-build-test-numpy-build-run-xx
+  version: 1.0
+
+requirements:
+  build:
+    - python
+    - numpy
+  run:
+    - python
+    - numpy x.x

--- a/tests/test-recipes/metadata/numpy_build_run_xx/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_run_xx/run_test.bat
@@ -1,0 +1,5 @@
+@echo on
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-run-xx-1\.0-np..py.._0"
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build_run_xx/run_test.py
+++ b/tests/test-recipes/metadata/numpy_build_run_xx/run_test.py
@@ -1,0 +1,22 @@
+import os
+import json
+import glob
+
+def main():
+    prefix = os.environ['PREFIX']
+    print(prefix)
+    info_files = glob.glob(os.path.join(prefix, 'conda-meta',
+                             'conda-build-test-numpy-build-run-xx-1.0-np*py*0.json'))
+    assert len(info_files) == 1
+    info_file = info_files[0]
+    with open(info_file, 'r') as fh:
+        info = json.load(fh)
+
+    assert len(info['depends']) == 2
+    depends = sorted(info['depends'])
+    # With no version
+    assert depends[0].startswith('numpy ')
+    assert depends[1].startswith('python ')
+
+if __name__ == '__main__':
+    main()

--- a/tests/test-recipes/metadata/numpy_build_run_xx/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build_run_xx/run_test.sh
@@ -1,0 +1,4 @@
+echo $PATH
+conda list -p $PREFIX --canonical
+# Test the build string. Should contain NumPy, but not the version
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-xx-1.0-np..py.._0"

--- a/tests/test-recipes/metadata/numpy_build_run_xx_different_spec/meta.yaml
+++ b/tests/test-recipes/metadata/numpy_build_run_xx_different_spec/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: conda-build-test-numpy-build-run-xx-different-spec
+  version: 1.0
+
+requirements:
+  build:
+    - python
+    - numpy >=1.7
+  run:
+    - python
+    - numpy x.x

--- a/tests/test-recipes/metadata/numpy_build_run_xx_different_spec/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_run_xx_different_spec/run_test.bat
@@ -1,0 +1,5 @@
+@echo on
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-run-xx-different-spec-1\.0-np..py.._0"
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build_run_xx_different_spec/run_test.py
+++ b/tests/test-recipes/metadata/numpy_build_run_xx_different_spec/run_test.py
@@ -1,0 +1,22 @@
+import os
+import json
+import glob
+
+def main():
+    prefix = os.environ['PREFIX']
+    print(prefix)
+    info_files = glob.glob(os.path.join(prefix, 'conda-meta',
+                             'conda-build-test-numpy-build-run-xx-different-spec-1.0-np*py*0.json'))
+    assert len(info_files) == 1
+    info_file = info_files[0]
+    with open(info_file, 'r') as fh:
+        info = json.load(fh)
+
+    assert len(info['depends']) == 2
+    depends = sorted(info['depends'])
+    # With no version
+    assert depends[0].startswith('numpy ')
+    assert depends[1].startswith('python ')
+
+if __name__ == '__main__':
+    main()

--- a/tests/test-recipes/metadata/numpy_build_run_xx_different_spec/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build_run_xx_different_spec/run_test.sh
@@ -1,0 +1,4 @@
+echo $PATH
+conda list -p $PREFIX --canonical
+# Test the build string. Should contain NumPy, but not the version
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-xx-different-spec-1.0-np..py.._0"


### PR DESCRIPTION
This adds a few tests, some of which currently won't pass but should once the `numpy x.x` is implemented properly as a runtime requirement:

 + `numpy x.x` in the build requirements should raise an error (check assumes a `RuntimeError` but don't have strong feelings about that). Test currently fails.

+ `numpy x.x` as a runtime requirement should pin the version of numpy in the build requirements to the value of `CONDA_NPY` no matter what the numpy build requirement is listed as. Right now this test succeeds in one case but fails in another:

     + Succeeds if the build requirement is `numpy`.
     + Fails if the build requirement is `numpy >=1.7`.

+ Recipes with `numpy x.x` in their runtime requirement should include the proper numpy in their build id. Tests pass.